### PR TITLE
Remplace Maybe by Either in case of socket error

### DIFF
--- a/Network/DefaultHttpEngine.idr
+++ b/Network/DefaultHttpEngine.idr
@@ -76,8 +76,8 @@ defaultHttpEngineRunApplication : {m : Type -> Type}
                  -> ST m String []
 defaultHttpEngineRunApplication {m} {tcpSockets} bindTo port app =
   do
-    Just listenerSocket <- socket tcpSockets
-      | Nothing => pure "Can't create listener socket"
+    Right listenerSocket <- socket tcpSockets
+      | Left code => pure  ("Can't create listener socket on address " ++ (show bindTo) ++ ", error code: " ++ (show code))
     True <- bind tcpSockets bindTo port listenerSocket
       | False => do
          close tcpSockets listenerSocket

--- a/Network/ST/TcpSockets.idr
+++ b/Network/ST/TcpSockets.idr
@@ -38,7 +38,7 @@ public export record TcpSockets (m : Type -> Type) where
   Sock : TcpSocketState -> Type
   -- A socket which is connected or failed, and which stores its state at runtime
   CFSock : Type
-  socket : ST m (Maybe Var) [addIfJust $ Sock Ready]
+  socket : ST m (Either Int Var) [addIfRight $ Sock Ready]
   bind : (bindAddr: Maybe SocketAddress)
          -> (port : Int)
          -> (sock : Var)
@@ -74,9 +74,9 @@ ioTcpSockets = MkTcpSockets
   {- CFSock -} (State (Socket, Bool))
   {- socket -} (do
     Right rawSocket <- lift $ Socket.socket AF_INET6 Stream 0
-      | Left _ => pure Nothing
+      | Left err => pure (Left err)
     lbl <- new rawSocket
-    pure (Just lbl))
+    pure (Right lbl))
   {- bind -} (\addr => \port => \sockVar => do
     resultCode <- (lift $ Socket.bind !(read sockVar) addr port)
     if resultCode == 0 then


### PR DESCRIPTION
I've had some issue where creating a socket would error but the diagnostic would be lost in a `Nothing` return value.

This PR replaces the `Maybe` type by a `Either` type returning the error code in a `Left Int` in case of error.