### PR TITLE
Respond according to requested path

### DIFF
--- a/Network/DefaultHttpEngine.idr
+++ b/Network/DefaultHttpEngine.idr
@@ -121,7 +121,7 @@ defaultHttpEngineRunApplication {m} {tcpSockets} bindTo port app =
         | Just InvalidRequest => pure (Just InvalidRequest)
       -- TODO: HTTP/2
       if (version == "HTTP/1.1" || version == "HTTP/1.0")
-        then pure $ Just $ ValidRequest $ MkHttpRequest method httpHeaders ""
+        then pure $ Just $ ValidRequest $ MkHttpRequest method path httpHeaders ""
         else pure (Just InvalidRequest)
   
     withContentLength : HttpRequest -> Maybe Nat

--- a/Network/Wai.idr
+++ b/Network/Wai.idr
@@ -18,6 +18,7 @@ public export
 record HttpRequest where
   constructor MkHttpRequest
   method : String
+  path : String
   headers : List HttpHeader
   body : String
 
@@ -59,3 +60,7 @@ getHttpHeader hn req = find (\h => toLower (headerName h) == toLower hn) (header
 export
 http200 : HttpResponseCode
 http200 = MkHttpResponseCode 200 "OK"
+
+export
+http404 : HttpResponseCode
+http404 = MkHttpResponseCode 404 "Not Found"

--- a/examples/Simple.idr
+++ b/examples/Simple.idr
@@ -10,7 +10,11 @@ specificEngine = defaultHttpEngine IO ioTcpSockets
 mainST : ST IO String []
 mainST = runApplication specificEngine Nothing 8080 $
            mkApplication specificEngine $ \engineState, req => do
-            sendResponse specificEngine engineState (MkHttpResponse http200 [] "It works!")
+            sendResponse specificEngine engineState $
+              case path req of
+                "/" => MkHttpResponse http200 [] "It works!"
+                "/hello" => MkHttpResponse http200 [] "Hello world!"
+                _ => MkHttpResponse http404 [] ""
 
 main : IO ()
 main = do


### PR DESCRIPTION
It is not currently possible to respond according to the requested path. To facilitate this, this change includes the path in the `HttpRequest` type, which allows the `HttpResponse` to be a function of the requested path, as well as the other attributes of a request (method, headers and body).