### PR TITLE
Fix quoted reason phrase in response

### DIFF
--- a/Network/DefaultHttpEngine.idr
+++ b/Network/DefaultHttpEngine.idr
@@ -42,7 +42,7 @@ httpResponseToString : HttpResponse -> String
 httpResponseToString resp =
   joinByCRLF $ 
    ("HTTP/1.1 " ++ (show . responseNumber . code $ resp) ++ " " ++
-    (show . responseText . code $ resp))::
+    (responseText . code $ resp))::
    ((map httpHeaderToString
          ((MkHttpHeader "Content-Length" (show . Strings.length . body $ resp)) ::
           (headers resp))) ++ ["", body resp])


### PR DESCRIPTION
The reason phrase associated with the status code is surrounded in double quotes, for example:

- `HTTP/1.1 200 "OK"`
- `HTTP/1.1 404 "Not Found"`

This change removes the double quotes, so that the response looks like:

- `HTTP/1.1 200 OK`
- `HTTP/1.1 404 Not Found`

The surrounding quotes are not violating the [HTTP specification](https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html), which does not apply any semantic value to the reason phrase. However, all examples of reason phrases, both in the HTTP specification, as well as from other HTTP servers, are not quoted.